### PR TITLE
Added period_search override to lomb_scargle

### DIFF
--- a/periodogram/lomb_scargle.py
+++ b/periodogram/lomb_scargle.py
@@ -1,6 +1,6 @@
 from astroML.time_series import multiterm_periodogram
 from scipy.interpolate import UnivariateSpline as interpolate
-import numpy as np        
+import numpy as np
 
 from .base import PeriodicModeler
 
@@ -30,4 +30,14 @@ class LombScargle(PeriodicModeler):
             raise RuntimeError("Need to fit data first.")
         else:
             return self.power_fn(period)
-
+    
+    def period_search(self, pmin=None, pmax=None, resolution=None, **kwargs):
+        """Find the best period for the model"""
+        if pmin is None: 
+            pmin = min(self.periods)
+        if pmax is None:
+            pmax = max(self.periods)
+        if resolution is None:
+            resolution = len(self.periods))
+        return super(LombScargle).period_search(pmin, pmax, 
+                resolution=resolution, **kwargs)

--- a/periodogram/lomb_scargle.py
+++ b/periodogram/lomb_scargle.py
@@ -34,10 +34,10 @@ class LombScargle(PeriodicModeler):
     def period_search(self, pmin=None, pmax=None, resolution=None, **kwargs):
         """Find the best period for the model"""
         if pmin is None: 
-            pmin = min(self.periods)
+            pmin = self.periods.min()
         if pmax is None:
-            pmax = max(self.periods)
+            pmax = self.periods.max()
         if resolution is None:
-            resolution = len(self.periods))
+            resolution = len(self.periods)
         return super(LombScargle).period_search(pmin, pmax, 
                 resolution=resolution, **kwargs)


### PR DESCRIPTION
Added in a period_seach override to lomb_scargle, which supplies default values for the superclass's period_search. The pmin, pmax, and resolution defaults are derived from LombScargle's self.period variable.
